### PR TITLE
Update rust docker image to 1.74

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.69-slim-buster
+FROM rust:1.74-slim-buster
 
 WORKDIR /usr/src/rusthound
 


### PR DESCRIPTION
Compiling with Docker is failing on 1.69 due to dependencies requiring a newer Rust version:

```
error: package `clap_lex v0.5.1` cannot be built because it requires rustc 1.70.0 or newer, while the currently active rustc version is 1.69.0
Either upgrade to rustc 1.70.0 or newer, or use
cargo update -p clap_lex@0.5.1 --precise ver
where `ver` is the latest version of `clap_lex` supporting rustc 1.69.0
```

With this change it's possible to compile RustHound on Docker again:

```
sudo docker run --rm -v `pwd`:/usr/src/rusthound rusthound windows
[snip]
-e [+] You can find rusthound.exe in yout current folder.
```