### PR TITLE
Add collected flag

### DIFF
--- a/src/objects/domain.rs
+++ b/src/objects/domain.rs
@@ -157,7 +157,7 @@ impl Domain {
                 _ => {}
             }
         }
-        // For all, bins attributs
+        // For all, bins attributes
         for (key, value) in &result_bin {
             match key.as_str() {
                 "objectSid" => {
@@ -171,6 +171,9 @@ impl Domain {
                         self.properties.domainsid = domain_sid[0].to_owned().to_string();
                         global_domain_sid = domain_sid[0].to_owned().to_string();
                     }
+
+                    // Data Quality flag
+                    self.properties.collected = true;
                 }
                 "nTSecurityDescriptor" => {
                     // Needed with acl
@@ -276,5 +279,6 @@ pub struct DomainProperties {
     highvalue: bool,
     description: Option<String>,
     whencreated: i64,
-    functionallevel: String
+    functionallevel: String,
+    collected: bool
 }


### PR DESCRIPTION
Similar to the PR to BloodHound.py - https://github.com/dirkjanm/BloodHound.py/issues/138#issuecomment-1847589058

I've added a collected flag to satisfy the BloodHound CE Data Quality page

I also only add this flag if the domain SID has been resolved, otherwise I ended up with unwanted results as seen below:

![image](https://github.com/NH-RED-TEAM/RustHound/assets/78267628/46e7589d-6fd2-4752-b8a1-5ca390a47264)

This is also my first two lines of Rust code so feel free to change if the logic is incorrect!